### PR TITLE
[CI] Update ddev action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         run: mv "./.ddev/docker-compose.chrome.yaml.inactive" "./.ddev/docker-compose.chrome.yaml"
 
       - name: Start DDEV
-        uses: jonaseberle/github-action-setup-ddev@v1
+        uses: ddev/github-action-setup-ddev@v1
 
       - name: Import database
         run: ddev import-db --src=./data/db.sql


### PR DESCRIPTION
"jonaseberle/github-action-setup-ddev" has been deprecated in favor of "ddev/github-action-setup-ddev".

This also fixes the error on workflow run:

    Invalid configuration in /home/runner/.ddev/global_config.yaml: invalid omit_containers: dba,ddev-ssh-agent, must contain only ddev-router,ddev-ssh-agent

Releases: main, v12-0, v11-0