### PR TITLE
[BUGFIX] Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ update-page-permissions:
 update: update-sitepackage update-composer update-page-permissions ## Update everything
 
 .PHONY: install
-install: update restart setup create-editors update-page-permissions ## Install everything
+install: update-sitepackage update-composer restart setup create-editors update-page-permissions ## Install everything
 
 .PHONY: restart
 restart: ## Restart DDEV


### PR DESCRIPTION
"update" may not be called as a combined target, as it contains "update-page-permissions" which may not be called in "install" before all install steps are finished.